### PR TITLE
re-adding "listen-in" to the menu

### DIFF
--- a/assets/www/android/platform.js
+++ b/assets/www/android/platform.js
@@ -38,6 +38,7 @@ function setPageActionsState(state) {
 	setMenuItemState("read-in", state, true);
 	setMenuItemState("save-page", state, true);
 	setMenuItemState("share-page", state, true);
+	setMenuItemState("listen-sound", state, true);
 }
 
 window.CREDITS = [
@@ -143,6 +144,7 @@ function updateMenuState() {
 		'go-forward': function() { chrome.goForward(); },
 		'select-text': function() { selectText(); },
 		'view-settings': function() { appSettings.showSettings(); },
+		'listen-sound': function() { audioPlayer.createMenuArray(); },
 	};
 	$('#appMenu command').each(function() {
 		var $command = $(this),

--- a/assets/www/js/app.js
+++ b/assets/www/js/app.js
@@ -48,9 +48,11 @@ window.app = function() {
 						loadLocalPage('error.html');
 					}
 					languageLinks.clearLanguages();
-					setMenuItemState('read-in', false);
-					setPageActionsState(false);
 					audioPlayer.clearMenuArray();
+					setMenuItemState('read-in', false);
+					setMenuItemState('listen-sound', false);
+					setPageActionsState(false);
+					
 				}
 			});
 		};


### PR DESCRIPTION
updated the menu_handler to have an entry for listen in
clears the menu like they do for the language menu
