### PR TITLE
Fixed selecting items on the screen not working in Android 4.x

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -245,10 +245,6 @@
 			<div id="langList"></div>
 		</div>
 	</div>
-	
-	<div id="content" class="scroller">
-		<div id="main"></div>
-	</div>
 
 	<div id="audiolinks">
 		<header>

--- a/assets/www/js/chrome.js
+++ b/assets/www/js/chrome.js
@@ -344,8 +344,7 @@ window.chrome = function() {
 		MobileFrontend.init();
 		window.scroll(0,0);
 		appHistory.addCurrentPage();
-		chrome.hideSpinner();  
-		audioPlayer.getMediaList();  
+		chrome.hideSpinner();   
 		console.log('currentHistoryIndex '+currentHistoryIndex + ' history length '+pageHistory.length);
 	}
 


### PR DESCRIPTION
Removed duplicate div in index.html that was preventing "clicks" from registering in newer android versions.

Also removed a redundant line of code from chrome.js as I already called that function earlier. 
