### PR TITLE
Fixing ruined CSS file

### DIFF
--- a/assets/www/app.css
+++ b/assets/www/app.css
@@ -605,12 +605,12 @@ body[dir=rtl] #settingsList .item select {
 	.goodscroll.overlay-open #content {
 		left: 320px;
 	}
-	.goodscroll #savedPages, .goodscroll #history, .goodscroll #settings, .goodscroll #searchresults, .goodscroll #langlinks, .goodscroll #about-page-overlay, .goodscroll #audiolinks {
 	.goodscroll #savedPages,
 	.goodscroll #history,
 	.goodscroll #settings,
 	.goodscroll #searchresults,
-	.goodscroll #langlinks {
+	.goodscroll #langlinks,
+  .goodscroll #audiolinks {
 		width: 320px;
 	}
 	.goodscroll .scroller {


### PR DESCRIPTION
A CSS file got messed up during a merge conflict. Was causing CSS problems on any device with a screen wider than 640px.

Fixes https://bugzilla.wikimedia.org/show_bug.cgi?id=35591
