### PR TITLE
Gracefully handle sharing from Wiktionary to Wiktionary

### DIFF
--- a/src/org/wiktionary/WiktionaryActivity.java
+++ b/src/org/wiktionary/WiktionaryActivity.java
@@ -37,14 +37,11 @@ public class WiktionaryActivity extends DroidGap {
         if (startedFromAnotherApp) { // Specify the word display on startup
 
           // See if we came from another wiki app (and thus have to parse a url)
-          String[] recognizedUrl = { "wiktionary.org/wiki/", "wikipedia.org/wiki/" };
-          for (String urlSubstring : recognizedUrl) {
-        	  int position = wordToShow.indexOf(urlSubstring);
-        	  if (position != -1) {
-        		  wordToShow = wordToShow.substring(position + urlSubstring.length());
-        		  break;
-        	  }
-          }
+          String wikiUrl = "/wiki/";
+    	  int position = wordToShow.indexOf(wikiUrl);
+    	  if (position != -1) {
+    		  wordToShow = wordToShow.substring(position + wikiUrl.length());
+    	  }
 
           wordToShow = URLEncoder.encode(wordToShow);
           startingUrl += "?define=" + wordToShow;


### PR DESCRIPTION
This detects if we are coming from Wiktionary by seeing if we were given a Wiktionary URL.
If so, then it extracts the word to define from the URL.
Since we personally know the Wikipedia app I also provide the possibility to parse the URL that they share with us, however this is not a solution that will easily scale to other MediaWiki products.

Additionally, if we are given any other types of url we will not know how to extract the word to define. We can either leave it at that or try to employ some kind of best guess. Example, the last term after a slash character, or check for get parameters like "?term=" or "?word=" or "?q=".

Feel free to comment.
