### PR TITLE
Changing placement of menu icons

### DIFF
--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -268,7 +268,7 @@
 	<menu id="appMenu" type="context">
 		<command type="command" id="languageCmd" icon="optionLanguage.png" disabled="true" action="read-in" />
 		<command type="command" id="soundCmd" icon="optionListen.png" disabled="true" action="listen-sound" />
-		<command type="command" id="sharePageCmd" disabled="false" action="share-page" />
+		<command type="command" id="sharePageCmd" icon="optionSharePage.png" disabled="false" action="share-page" />
 		<command type="command" id="savePageCmd" icon="optionAddBookmark.png" disabled="false" action="save-page" />
 		<command type="command" id="savedPagesCmd" icon="optionReadLater.png" disabled="false" action="view-saved-pages" />
 		<command type="command" id="historyCmd" icon="optionViewHistory.png" disabled="false" action="view-history" />


### PR DESCRIPTION
Fixing the menu to have the same icons as Wikipedia, in the same order. This will reduce confusion to users who use both apps. The only difference is that Wikipedia's Nearby has been replaced with our Listen In

<a href="http://dl.dropbox.com/u/4187555/Screenshot_2012-04-02-11-16-14.png">Before</img>
<a href="http://dl.dropbox.com/u/4187555/Screenshot_2012-04-02-11-31-12.png">After</img>
<a href="http://dl.dropbox.com/u/4187555/Screenshot_2012-04-02-11-43-43.png">Wikipedia</img>

Suggestions are welcome.
