### PR TITLE
Fixing disappearing buttons on Galaxy Nexus

### DIFF
--- a/assets/www/common.css
+++ b/assets/www/common.css
@@ -336,6 +336,7 @@ button.show {
 	display: none;
 }
 
+/* HACK to fix disappearing buttons on Galaxy Nexus */
 @media screen and (-webkit-device-pixel-ratio: 2.0) {
   button.show,
   button.hide {


### PR DESCRIPTION
This is a fix to the disappearing buttons on galaxy nexus, by custom styling the buttons. This, for whatever reason, prevents the buttons from disappearing.

Pros: Galaxy Nexus users will no longer see disappearing buttons.
Cons:
Buttons do not look native on Nexus
Affects all devices with screen ratio 2.0

Solution should only be used as a temporary measure. When we move away from MobileFrontend this will no longer be necessary, and hence will be merged into v1.0.1 only (not master).

Screenshots (taken on Galaxy Nexus):
http://dl.dropbox.com/u/4187555/Screenshot_2012-04-11-12-32-23.png

Tested on Nexus and emulator. Would love it if people could try this out on other phones.
