### PR TITLE
Now showing alert when no available audio

### DIFF
--- a/assets/www/android/platform.js
+++ b/assets/www/android/platform.js
@@ -141,6 +141,14 @@ function sharePage() {
 	);
 }
 
+function showAudio() {
+	if (audioPlayer.isAvailable()) {
+		audioPlayer.createMenuArray();
+	}else {
+		chrome.showNotification("audio unavailable for this page");
+	}
+}
+
 chrome.showNotification = function(text) {
 	// Using PhoneGap-Toast plugin for Android's lightweight "Toast" style notifications.
 	// https://github.com/m00sey/PhoneGap-Toast
@@ -160,7 +168,7 @@ function updateMenuState() {
 		'go-forward': function() { chrome.goForward(); },
 		'select-text': function() { selectText(); },
 		'view-settings': function() { appSettings.showSettings(); },
-		'listen-sound': function() { audioPlayer.createMenuArray(); },
+		'listen-sound': function() { showAudio(); },
         'word-of-the-day': function() { chrome.loadWordoftheDay(); },
 	};
 	$('#appMenu command').each(function() {

--- a/assets/www/index.html
+++ b/assets/www/index.html
@@ -267,7 +267,7 @@
 
 	<menu id="appMenu" type="context">
 		<command type="command" id="languageCmd" icon="optionLanguage.png" disabled="true" action="read-in" />
-		<command type="command" id="soundCmd" icon="optionListen.png" disabled="true" action="listen-sound" />
+		<command type="command" id="soundCmd" icon="optionListen.png" disabled="false" action="listen-sound" />
 		<command type="command" id="sharePageCmd" icon="optionSharePage.png" disabled="false" action="share-page" />
 		<command type="command" id="savePageCmd" icon="optionAddBookmark.png" disabled="false" action="save-page" />
 		<command type="command" id="savedPagesCmd" icon="optionReadLater.png" disabled="false" action="view-saved-pages" />

--- a/assets/www/js/media.js
+++ b/assets/www/js/media.js
@@ -3,7 +3,6 @@ window.audioPlayer = function() {
 	var availableMedia = [];
 	var availableUrl = [];
 	var menuArray = [];
-	var lastMenuStatus = false;
 	
 	/**
 	 * Function called with URL of file to be played.
@@ -36,12 +35,6 @@ window.audioPlayer = function() {
 	function getMediaList() {
 		var term = app.getCurrentTitle();
 		var requestUrl = app.baseURL + "/w/api.php";
-		
-		if (lastMenuStatus){
-			setMenuItemState('listen-sound',false, false);
-			console.log("disabling listen-in menu");
-			lastMenuStatus = false;
-		}	
 		
 		var ending = ".*\.ogg";
 		
@@ -101,13 +94,7 @@ window.audioPlayer = function() {
 				format: 'json'
 			},
 			success: function(data) {
-				
-				if(!lastMenuStatus){
-					setMenuItemState('listen-sound', true, false);
-					console.log("enabling listen-in menu");
-					lastMenuStatus = true;		
-				}	
-		
+
 				for(var id in data.query.pages){
 					for (var im in data.query.pages[id].imageinfo){		
 						
@@ -160,6 +147,10 @@ window.audioPlayer = function() {
 		menuArray = [];
 	}
 	
+	function isAvailable() {
+		return (availableUrl.length != 0); 
+	}
+	
 	
 	/**
 	 * plays file that is clicked in the menu
@@ -180,6 +171,7 @@ window.audioPlayer = function() {
 		playAudio: playAudio,
 		releaseMedia: releaseMedia,
 		getMediaList: getMediaList,
+		isAvailable: isAvailable,
 		createMenuArray: createMenuArray,
 		clearMenuArray: clearMenuArray
 	};


### PR DESCRIPTION
The Listen-in button is now not darkened and disabled where there is nothing to play, and will show a notification with a helpful message instead. I think its a lot more intuitive than what we had before. 

As far as I can tell, I can't both darken and show a notification.
