### PR TITLE
Update app_name

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ويكيبيديا</string>
+	<string name="app_name">ويكاموس</string>
 </resources>

--- a/res/values-az/strings.xml
+++ b/res/values-az/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipediya</string>
+	<string name="app_name">Vikilüğət</string>
 </resources>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Уикипедия</string>
+	<string name="app_name">Уикиречник</string>
 </resources>

--- a/res/values-bn/strings.xml
+++ b/res/values-bn/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">উইকিপিডিয়া</string>
+	<string name="app_name">উইকিঅভিধান</string>
 </resources>

--- a/res/values-bs/strings.xml
+++ b/res/values-bs/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wiktionary</string>
+	<string name="app_name">Wikirječnik</string>
 </resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Viquipèdia</string>
+	<string name="app_name">Viccionari</string>
 </resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipedie</string>
+	<string name="app_name">Wikislovník</string>
 </resources>

--- a/res/values-cv/strings.xml
+++ b/res/values-cv/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википеди</string>
+	<string name="app_name">Викисăмахсар</string>
 </resources>

--- a/res/values-cy/strings.xml
+++ b/res/values-cy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wicipedia</string>
+	<string name="app_name">Wiciadur</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Βικιπαίδεια</string>
+	<string name="app_name">Βικιλεξικό</string>
 </resources>

--- a/res/values-eo/strings.xml
+++ b/res/values-eo/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipedio</string>
+	<string name="app_name">Vikivortaro</string>
 </resources>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipeedia</string>
+	<string name="app_name">Vikisõnastik</string>
 </resources>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ویکی‌پدیا</string>
+	<string name="app_name">ویکی‌واژه</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipédia</string>
+	<string name="app_name">Wiktionnaire</string>
 </resources>

--- a/res/values-fy/strings.xml
+++ b/res/values-fy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipedy</string>
+	<string name="app_name">Wikiwurdboek</string>
 </resources>

--- a/res/values-gd/strings.xml
+++ b/res/values-gd/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Uicipeid</string>
+	<string name="app_name">Faclair na h-uicipeid</string>
 </resources>

--- a/res/values-gu/strings.xml
+++ b/res/values-gu/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">વિકિપીડિયા</string>
+	<string name="app_name">વિક્શનરી</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">विकिपीडिया</string>
+	<string name="app_name">विक्षनरी</string>
 </resources>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipedija</string>
+	<string name="app_name">Wječnik</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipédia</string>
+	<string name="app_name">Wikiszótár</string>
 </resources>

--- a/res/values-hy/strings.xml
+++ b/res/values-hy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Վիքիփեդիա</string>
+	<string name="app_name">Վիքիբառարան</string>
 </resources>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ויקיפדיה</string>
+	<string name="app_name">ויקימילון</string>
 </resources>

--- a/res/values-ka/strings.xml
+++ b/res/values-ka/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ვიკიპედია</string>
+	<string name="app_name">ვიქსიკონი</string>
 </resources>

--- a/res/values-km/strings.xml
+++ b/res/values-km/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">វិគីភីឌា</string>
+	<string name="app_name">វិគីនានុក្រម</string>
 </resources>

--- a/res/values-kn/strings.xml
+++ b/res/values-kn/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ವಿಕಿಪೀಡಿಯ</string>
+	<string name="app_name">ವಿಕ್ಷನರಿ</string>
 </resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">위키백과</string>
+	<string name="app_name">위키낱말사전</string>
 </resources>

--- a/res/values-la/strings.xml
+++ b/res/values-la/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vicipaedia</string>
+	<string name="app_name">Victionarium</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipedija</string>
+	<string name="app_name">Vikižodynas</string>
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipēdija</string>
+	<string name="app_name">Vikivārdnīca</string>
 </resources>

--- a/res/values-mk/strings.xml
+++ b/res/values-mk/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википедија</string>
+	<string name="app_name">Викиречник</string>
 </resources>

--- a/res/values-ml/strings.xml
+++ b/res/values-ml/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">വിക്കിപീഡിയ</string>
+	<string name="app_name">വിക്കി നിഘണ്ടു</string>
 </resources>

--- a/res/values-mn/strings.xml
+++ b/res/values-mn/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википедиа</string>
+	<string name="app_name">Вики толь</string>
 </resources>

--- a/res/values-mr/strings.xml
+++ b/res/values-mr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">विकिपीडिया</string>
+	<string name="app_name">विक्शनरी</string>
 </resources>

--- a/res/values-mt/strings.xml
+++ b/res/values-mt/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipedija</string>
+	<string name="app_name">Wikizzjunarju</string>
 </resources>

--- a/res/values-ne/strings.xml
+++ b/res/values-ne/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">विकिपीडिया</string>
+	<string name="app_name">विक्सनरी</string>
 </resources>

--- a/res/values-oc/strings.xml
+++ b/res/values-oc/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipèdia</string>
+	<string name="app_name">Wikiccionari</string>
 </resources>

--- a/res/values-or/strings.xml
+++ b/res/values-or/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ଉଇକିପିଡ଼ିଆ</string>
+	<string name="app_name">ଉଇକିଅଭିଧାନ</string>
 </resources>

--- a/res/values-os/strings.xml
+++ b/res/values-os/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википеди</string>
+	<string name="app_name">Викидзырдуат</string>
 </resources>

--- a/res/values-pa/strings.xml
+++ b/res/values-pa/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ਵਿਕਿਪੀਡਿਆ</string>
+	<string name="app_name">ਵਿਕਸ਼ਨਰੀ</string>
 </resources>

--- a/res/values-ps/strings.xml
+++ b/res/values-ps/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">ويکيپېډيا</string>
+	<string name="app_name">ويکيسيند</string>
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipédia</string>
+	<string name="app_name">Wikcionário</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википедия</string>
+	<string name="app_name">Викисловарь</string>
 </resources>

--- a/res/values-sa/strings.xml
+++ b/res/values-sa/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">विकिपीडिया</string>
+	<string name="app_name">विक्शनरी</string>
 </resources>

--- a/res/values-si/strings.xml
+++ b/res/values-si/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">විකිපීඩියා, නිදහස් විශ්වකෝෂය</string>
+	<string name="app_name">වික්‍ෂනරි</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipédia</string>
+	<string name="app_name">Wikislovník</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Wikipedija</string>
+	<string name="app_name">Wikislovar</string>
 </resources>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Википедија</string>
+	<string name="app_name">Викиречник</string>
 </resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">விக்கிப்பீடியா</string>
+	<string name="app_name">விக்சனரி</string>
 </resources>

--- a/res/values-te/strings.xml
+++ b/res/values-te/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">వికీపీడియా</string>
+	<string name="app_name">విక్షనరీ</string>
 </resources>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">วิกิพีเดีย</string>
+	<string name="app_name">วิกิพจนานุกรม</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipedi</string>
+	<string name="app_name">Vikisözlük</string>
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Вікіпедія</string>
+	<string name="app_name">Вікісловник</string>
 </resources>

--- a/res/values-ur/strings.xml
+++ b/res/values-ur/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">منصوبہ</string>
+	<string name="app_name">ویکی‌لُغت</string>
 </resources>

--- a/res/values-uz/strings.xml
+++ b/res/values-uz/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">Vikipediya</string>
+	<string name="app_name">Vikilug‘at</string>
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">维基百科</string>
+	<string name="app_name">维基词典</string>
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-<string name="app_name">維基百科</string>
+	<string name="app_name">維基詞典</string>
 </resources>


### PR DESCRIPTION
The app_name for many languages was translations of 'Wikipedia'
instead of 'Wiktionary'.  Update using sitename.

Fixes #40

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wikimedia/wiktionarymobile/41)
<!-- Reviewable:end -->
